### PR TITLE
Refactor: Simplify Hail initialization by removing explicit Spark con…

### DIFF
--- a/src/prepare_base_vds.py
+++ b/src/prepare_base_vds.py
@@ -18,7 +18,6 @@ def parse_args():
     parser.add_argument("--run_timestamp", required=True, help="Run timestamp (YYYYMMDD_HHMMSS) for Hail logging.")
     parser.add_argument("--gcs_temp_dir", required=True, help="GCS base directory for stable intermediate checkpoints (VDS, ID lists).")
     parser.add_argument("--gcs_hail_temp_dir", required=True, help="GCS temporary directory specifically for Hail shuffle/intermediate operations.")
-    parser.add_argument("--spark_configurations_json", required=True, help="JSON string of Spark configurations for Hail initialization.")
     parser.add_argument("--wgs_vds_path", required=True, help="GCS path to the full input WGS VDS.")
     parser.add_argument("--flagged_samples_gcs_path", required=True, help="GCS path to the TSV file containing flagged sample IDs.")
     parser.add_argument("--base_cohort_vds_path_out", required=True, help="GCS output path for the prepared base cohort VDS checkpoint.")
@@ -299,7 +298,6 @@ def main():
     init_hail(
         gcs_hail_temp_dir=args.gcs_hail_temp_dir,
         log_suffix=args.run_timestamp, # Using run_timestamp as the log suffix for this script
-        spark_configurations_json_str=args.spark_configurations_json,
         cluster_mode=args.hail_cluster_mode # Pass the cluster mode to Hail initialization
     )
     # Set a default number of partitions for Hail operations to improve GCS I/O and prevent too many small files.

--- a/src/process_prs_model.py
+++ b/src/process_prs_model.py
@@ -553,7 +553,6 @@ def main():
     parser.add_argument('--output_final_hail_table_gcs_path', required=True, help="GCS output path for the final scores Hail Table.")
     parser.add_argument('--output_final_score_csv_gcs_path',    required=True, help="GCS output path for the final scores CSV.")
     parser.add_argument('--google_billing_project',       required=True, help="Google Cloud Project ID for billing and GCS access.")
-    parser.add_argument('--spark_configurations_json',  required=True, help="JSON string of Spark configurations for Hail initialization.")
     parser.add_argument(
         "--hail_cluster_mode", 
         choices=["local", "dataproc_yarn"], 
@@ -572,7 +571,6 @@ def main():
     init_hail(
         gcs_hail_temp_dir=args.gcs_hail_temp_dir,
         log_suffix=f"{args.run_timestamp}_{prs_id}", # Using run_timestamp and prs_id for specific log name
-        spark_configurations_json_str=args.spark_configurations_json,
         cluster_mode=args.hail_cluster_mode # Pass the cluster mode to Hail initialization
     )
     # Set a default number of partitions for Hail operations.


### PR DESCRIPTION
…figurations

This change modifies Hail initialization to rely on environment-provided Spark configurations, particularly for Dataproc.

Key changes:
- Removed `spark_configurations_json_str` parameter and associated logic from `utils.init_hail`.
- `hl.init()` no longer receives an explicit `spark_conf` dictionary.
- `hl.default_reference` is now set after `hl.init()`.
- Removed `spark_conf_json` handling from `main.py` and the corresponding `--spark_configurations_json` argument from script calls.
- Removed `--spark_configurations_json` argument and its usage from `prepare_base_vds.py` and `process_prs_model.py`.

This simplification aims to resolve `[Errno 2] No such file or directory` errors encountered during Hail/Spark startup by behaving more like pre-configured Jupyter environments on Dataproc.